### PR TITLE
README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ go get -u go.mozilla.org/sops/cmd/sops
 ### Build & Install plugin
 
 ```
-mkdir -p ~/.config/kustomize/plugins/kvSources
-go build -buildmode plugin -o ~/.config/kustomize/plugins/kvSources/kustomize-sops.so kustomize-sops.go
+mkdir -p ~/.config/kustomize/plugin/kvSources
+go build -buildmode plugin -o ~/.config/kustomize/plugin/kvSources/kustomize-sops.so kustomize-sops.go
 ```
 
 ### Test/Run


### PR DESCRIPTION
Running
```
kustomize --enable_alpha_goplugins_accept_panic_risk build .
```

Produced this error:
```
Error: generating legacy configMaps and secrets: secretgenerator: [{{ mysecrets  {[] [] } [{go kustomize-sops [data."tokens.yaml"]}]} }]: NewResMapFromSecretArgs: plugins: : plugin.Open("/Users/franklee/.config/kustomize/plugin/kvSources/kustomize-sops.so"): realpath failed
```

Fixing the path made it work.